### PR TITLE
fix: fixing the broken image issue by adding a place holder image

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -38,7 +38,7 @@ const LoggedInView = (props) => {
       <li className="nav-item">
         <Link to={`/@${props.currentUser.username}`} className="nav-link">
           <img
-            src={props.currentUser.image}
+            src={props.currentUser.image || '/placeholder.png'}
             className="user-pic pr-1"
             alt={props.currentUser.username}
           />

--- a/frontend/src/components/Item/CommentInput.js
+++ b/frontend/src/components/Item/CommentInput.js
@@ -43,7 +43,7 @@ class CommentInput extends React.Component {
         </div>
         <div className="card-footer">
           <img
-            src={this.props.currentUser.image}
+            src={this.props.currentUser.image || '/placeholder.png'}
             className="user-pic mr-2"
             alt={this.props.currentUser.username}
           />

--- a/frontend/src/components/Item/ItemMeta.js
+++ b/frontend/src/components/Item/ItemMeta.js
@@ -9,7 +9,7 @@ const ItemMeta = (props) => {
       <Link to={`/@${item.seller.username}`}>
         <img
           id="seller-image"
-          src={item.seller.image}
+          src={item.seller.image || '/placeholder.png'}
           alt={item.seller.username}
           className="user-pic mr-2"
         />

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -48,7 +48,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || '/placeholder.png'}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || '/placeholder.png'}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description
The issue of broken images when there is no image URL provided by user while adding a new item is resolved by providing an alternate place holder image. Similarly the profile picture image is also provided with a place holder incase the user doesn't set a profile picture.

FYR: -

![image](https://user-images.githubusercontent.com/78893920/210502615-cd693961-1a72-4570-97ad-c97358e2dce9.png)

![image](https://user-images.githubusercontent.com/78893920/210502836-3a655ad6-2551-4c4b-b9a4-9d8a3702a9a5.png)
