### PR TITLE
fix: making the backend to always a url in case of user not providing…

### DIFF
--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -49,7 +49,7 @@ ItemSchema.methods.toJSONFor = function(user) {
     slug: this.slug,
     title: this.title,
     description: this.description,
-    image: this.image,
+    image: this.image || '/placeholder.png',
     createdAt: this.createdAt,
     updatedAt: this.updatedAt,
     tagList: this.tagList,


### PR DESCRIPTION
# Image

![image](https://user-images.githubusercontent.com/78893920/210506314-f24d58dd-4536-4f18-85e8-d3b49bda13e6.png)

# Description

Making the backend API to always return an placeholder URL, incase the user misses to provide an image source while creating a new Item.
